### PR TITLE
Open correct resource in dialog

### DIFF
--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -881,10 +881,11 @@ function ResourceOverviewInner({
         filteredResources
           ?.slice(page * pageSize, (page + 1) * pageSize)
           ?.map((resource: any, index: number) => {
+            const absoluteIndex = page * pageSize + index;
             return (
               <React.Fragment key={`resource-item-${resource?.id || resource?.uniqueId}`}>
                 {renderItem(resource, { ...props, displayType, selectedProjects, displayOverviewTagGroups, overviewTagGroups }, () => {
-                  onResourceClick(resource, index);
+                  onResourceClick(resource, absoluteIndex);
                 })}
               </React.Fragment>
             );


### PR DESCRIPTION
In the resource-overview-widget, when pagination is on and it is set to open the resources in the dialog-view when a tile is clicked, the wrong resource was opened in the dialog when you're on page > 1. This is fixed by using the `absoluteIndex`.